### PR TITLE
MAG-578: Fix to improve fulfillment compatibility

### DIFF
--- a/www/magento/app/code/community/Signifyd/Connect/Helper/Data.php
+++ b/www/magento/app/code/community/Signifyd/Connect/Helper/Data.php
@@ -1374,10 +1374,10 @@ class Signifyd_Connect_Helper_Data extends Mage_Core_Helper_Abstract
 
         /** @var Mage_Sales_Model_Order_Shipment_Track $tracking */
         foreach ($trackingCollection->getItems() as $tracking) {
-            $number = trim($tracking->getNumber());
+            $number = trim((string) $tracking->getNumber());
 
             if (empty($number) == false) {
-                $trackingNumbers[] = $tracking->getNumber();
+                $trackingNumbers[] = $number;
             }
         }
 

--- a/www/magento/app/code/community/Signifyd/Connect/etc/config.xml
+++ b/www/magento/app/code/community/Signifyd/Connect/etc/config.xml
@@ -186,6 +186,16 @@
                     </signifyd_connect>
                 </observers>
             </order_cancel_after>
+
+            <!-- Fulfilment events -->
+            <sales_order_shipment_track_save_commit_after>
+                <observers>
+                    <signifyd_connect>
+                        <model>signifyd_connect/observer</model>
+                        <method>salesOrderShipmentTrackSaveCommitAfter</method>
+                    </signifyd_connect>
+                </observers>
+            </sales_order_shipment_track_save_commit_after>
         </events>
     </global>
     <crontab>
@@ -294,15 +304,6 @@
                     </signifyd_connect>
                 </observers>
             </core_block_abstract_to_html_before>
-            <!-- Fulfilment events -->
-            <sales_order_shipment_track_save_commit_after>
-                <observers>
-                    <signifyd_connect>
-                        <model>signifyd_connect/observer</model>
-                        <method>salesOrderShipmentTrackSaveCommitAfter</method>
-                    </signifyd_connect>
-                </observers>
-            </sales_order_shipment_track_save_commit_after>
         </events>
     </adminhtml>
     <default>


### PR DESCRIPTION
Event moved from adminhtml to global, so now observer also listen to other areas like API requests
Cast tracking numbers to strings to correct in memory values like XML nodes (e.g.: when using ShipStation extension)